### PR TITLE
Issue Fix: EditableDiv's html state doesn't update when content property changes

### DIFF
--- a/EditableDiv.js
+++ b/EditableDiv.js
@@ -28,8 +28,14 @@ module.exports = React.createClass({
 		}.bind(this));
 	},
 
-	shouldComponentUpdate: function(nextProps) {
+    shouldComponentUpdate: function(nextProps) {
         return nextProps.content !== this.state.html;
+    },
+    
+    componentDidUpdate: function(prevProps, prevState){
+      this.setState({  
+        html: this.props.content  
+      }); 
     },
 
     execCommand: function(command, arg) {

--- a/EditableDiv.jsx
+++ b/EditableDiv.jsx
@@ -30,6 +30,12 @@ module.exports = React.createClass({
 	shouldComponentUpdate: function(nextProps) {
         return nextProps.content !== this.state.html;
     },
+    
+    componentDidUpdate: function(prevProps, prevState){
+      this.setState({  
+        html: this.props.content  
+      }); 
+    },
 
     execCommand: function(command, arg) {
     	document.execCommand(command, false, arg);


### PR DESCRIPTION
First off, I'm new to React but so far I'm enjoying it. Thank you for taking the time to write this component and share it with us! It's clean and performs quite well once an issue is taken care of.

This pull request should fix an issue that I (and I see someone else has) have been facing. Currently, EditableDiv requires whatever content it will load into the editor to be in the `getInitialState` of the host component but this isn't always ideal - take for example you're loading data from an API call.

The solution that worked for me is adding a `shouldComponentUpdate` function which sets the _html_ state to the updated _content_ property. Another solution uses `componentWillRecieveProps` to achieve the same result, but in my situation that solution didn't work. Having both will not negatively impact the result however.

Thanks again for the component, just thought I'd share my issue fix in case anyone else is having the same issue I did.
